### PR TITLE
Wire waitlist + contact forms to Appwrite at base.anchorit.dk

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -68,7 +68,7 @@
       var endpoint = SITE_CONFIG.APPWRITE_ENDPOINT;
       var projectId = SITE_CONFIG.APPWRITE_PROJECT_ID;
       var databaseId = SITE_CONFIG.APPWRITE_DATABASE_ID;
-      var collectionId = SITE_CONFIG.APPWRITE_COLLECTION_ID;
+      var tableId = SITE_CONFIG.APPWRITE_TABLE_ID;
 
       function showSuccess() {
         signupForm.classList.add("hidden");
@@ -82,7 +82,7 @@
         return;
       }
 
-      var url = endpoint + "/databases/" + databaseId + "/collections/" + collectionId + "/documents";
+      var url = endpoint + "/tablesdb/" + databaseId + "/tables/" + tableId + "/rows";
 
       fetch(url, {
         method: "POST",
@@ -91,7 +91,7 @@
           "X-Appwrite-Project": projectId,
         },
         body: JSON.stringify({
-          documentId: "unique()",
+          rowId: "unique()",
           data: { email: email },
         }),
       })
@@ -167,7 +167,7 @@
       var endpoint = SITE_CONFIG.APPWRITE_APP_ENDPOINT;
       var projectId = SITE_CONFIG.APPWRITE_APP_PROJECT_ID;
       var databaseId = SITE_CONFIG.APPWRITE_DATABASE_ID;
-      var collectionId = SITE_CONFIG.APPWRITE_CONTACT_COLLECTION_ID;
+      var tableId = SITE_CONFIG.APPWRITE_CONTACT_TABLE_ID;
 
       function showSuccess() {
         contactForm.classList.add("hidden");
@@ -185,7 +185,7 @@
         return;
       }
 
-      var url = endpoint + "/databases/" + databaseId + "/collections/" + collectionId + "/documents";
+      var url = endpoint + "/tablesdb/" + databaseId + "/tables/" + tableId + "/rows";
 
       fetch(url, {
         method: "POST",
@@ -193,7 +193,7 @@
           "Content-Type": "application/json",
           "X-Appwrite-Project": projectId,
         },
-        body: JSON.stringify({ documentId: "unique()", data: data }),
+        body: JSON.stringify({ rowId: "unique()", data: data }),
       })
         .then(function (response) {
           if (!response.ok) {

--- a/site.config.js
+++ b/site.config.js
@@ -6,17 +6,17 @@ const SITE_CONFIG = {
   SITE_MODE: "prelaunch",
 
   // Appwrite — waitlist email signup (prelaunch)
-  // Fill these in when the Appwrite project is ready; until then the form
-  // gracefully falls back to a local "thanks" UI.
-  APPWRITE_ENDPOINT: "",
-  APPWRITE_PROJECT_ID: "",
+  // Uses the TablesDB API (tables/rows). Falls back to a local "thanks" UI
+  // if endpoint/project are empty.
+  APPWRITE_ENDPOINT: "https://base.anchorit.dk/v1",
+  APPWRITE_PROJECT_ID: "website",
   APPWRITE_DATABASE_ID: "playdate",
-  APPWRITE_COLLECTION_ID: "waitlist",
+  APPWRITE_TABLE_ID: "waitlist",
 
   // Appwrite — contact form (can share or differ from the signup project)
   APPWRITE_APP_ENDPOINT: "",
   APPWRITE_APP_PROJECT_ID: "",
-  APPWRITE_CONTACT_COLLECTION_ID: "website_contact",
+  APPWRITE_CONTACT_TABLE_ID: "website_contact",
 
   // App store URLs (launched mode only)
   APP_STORE_URL: "https://apps.apple.com/dk/app/playdate/id000000000",


### PR DESCRIPTION
Closes #2

## Summary
- Populates `site.config.js` with Appwrite endpoint `https://base.anchorit.dk/v1` and project ID `website`
- Migrates both forms from the legacy `/databases/.../collections/.../documents` path (+ `documentId`) to Appwrite's new TablesDB API `/tablesdb/.../tables/.../rows` (+ `rowId`)
- Renames config keys `*_COLLECTION_ID` → `*_TABLE_ID` for consistency with the new API

## Required console setup on base.anchorit.dk
Before this works end-to-end:
1. Project `website` → add **Web platform** for `skalvilege.dk`, `incubatordk.github.io`, `localhost`
2. Database `playdate` → Table `waitlist`
   - Column `email` (string, required, size 320)
   - Permissions: role `Any` → Create only
   - Unique index on `email` (recommended)

## Test plan
- [ ] Submit the waitlist form on the deployed site; verify a new row appears in `playdate.waitlist`
- [ ] Submit an invalid email — form rejects without calling Appwrite
- [ ] Confirm the contact form still falls back to `mailto:` (its project is intentionally left unconfigured)
- [ ] Open browser devtools, confirm the request goes to `POST https://base.anchorit.dk/v1/tablesdb/playdate/tables/waitlist/rows` and returns 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)