### PR TITLE
Fix blog deployment links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ The waitlist form and contact form post to Appwrite. Until project IDs are fille
 
 ## Deployment
 
-Pushes to `main` auto-deploy to GitHub Pages via `.github/workflows/deploy.yml`. The `CNAME` file binds the custom domain `skalvilege.dk`.
+Pushes to `main` auto-deploy to GitHub Pages via `.github/workflows/deploy.yml`.
+
+Current public preview URL:
+
+```
+https://incubatordk.github.io/skalvilege.dk/
+```
+
+When the custom domain is moved, add a `CNAME` file containing `skalvilege.dk` and update canonical, sitemap, RSS and Open Graph URLs to `https://skalvilege.dk`.
 
 ## Structure
 
@@ -52,6 +60,5 @@ assets/                 — Logos, founder photos, profile images
 privacy-policy/         — GDPR privacy policy (da + en)
 terms.html              — Terms & Conditions
 robots.txt, sitemap.xml — SEO basics
-CNAME                   — GitHub Pages custom domain
 .nojekyll               — Skip Jekyll processing on GH Pages
 ```

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -2,21 +2,21 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Playdate Blog</title>
-    <link>https://skalvilege.dk/blog/</link>
+    <link>https://incubatordk.github.io/skalvilege.dk/blog/</link>
     <description>Noter om legeaftaler, børneliv og familieliv.</description>
     <language>da-dk</language>
     <copyright>Copyright 2026 Playdate</copyright>
     <lastBuildDate>Mon, 20 Apr 2026 06:00:00 +0000</lastBuildDate>
-    <atom:link href="https://skalvilege.dk/blog/feed.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://incubatordk.github.io/skalvilege.dk/blog/feed.xml" rel="self" type="application/rss+xml" />
     <image>
-      <url>https://skalvilege.dk/assets/blog/playdate-19-04.jpg</url>
+      <url>https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg</url>
       <title>Playdate Blog</title>
-      <link>https://skalvilege.dk/blog/</link>
+      <link>https://incubatordk.github.io/skalvilege.dk/blog/</link>
     </image>
     <item>
       <title>Lørdag formiddag, og ingen har spurgt endnu</title>
-      <link>https://skalvilege.dk/blog/lordag-formiddag/</link>
-      <guid isPermaLink="true">https://skalvilege.dk/blog/lordag-formiddag/</guid>
+      <link>https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/</link>
+      <guid isPermaLink="true">https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/</guid>
       <pubDate>Mon, 20 Apr 2026 06:00:00 +0000</pubDate>
       <author>playdate@skalvilege.dk (Playdate)</author>
       <description>Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.</description>

--- a/blog/index.html
+++ b/blog/index.html
@@ -5,22 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Blog — Playdate</title>
   <meta name="description" content="Fortællinger og noter om legeaftaler, børneliv og de små sociale tærskler i familielivet.">
-  <link rel="canonical" href="https://skalvilege.dk/blog/">
+  <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/blog/">
   <meta name="robots" content="index, follow">
 
   <meta property="og:title" content="Blog — Playdate">
   <meta property="og:description" content="Fortællinger og noter om legeaftaler, børneliv og de små sociale tærskler i familielivet.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://skalvilege.dk/blog/">
+  <meta property="og:url" content="https://incubatordk.github.io/skalvilege.dk/blog/">
   <meta property="og:locale" content="da_DK">
   <meta property="og:locale:alternate" content="en_GB">
   <meta property="og:site_name" content="Playdate">
-  <meta property="og:image" content="https://skalvilege.dk/assets/blog/playdate-19-04.jpg">
+  <meta property="og:image" content="https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Blog — Playdate">
   <meta name="twitter:description" content="Fortællinger og noter om legeaftaler, børneliv og de små sociale tærskler i familielivet.">
-  <meta name="twitter:image" content="https://skalvilege.dk/assets/blog/playdate-19-04.jpg">
+  <meta name="twitter:image" content="https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg">
 
   <script type="application/ld+json">
   {
@@ -28,14 +28,14 @@
     "@type": "Blog",
     "name": "Playdate Blog",
     "description": "Fortællinger og noter om legeaftaler, børneliv og de små sociale tærskler i familielivet.",
-    "url": "https://skalvilege.dk/blog/",
+    "url": "https://incubatordk.github.io/skalvilege.dk/blog/",
     "inLanguage": ["da", "en"],
     "publisher": {
       "@type": "Organization",
       "name": "Playdate",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://skalvilege.dk/assets/logo-color.svg"
+        "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
       }
     },
     "blogPost": [
@@ -43,7 +43,7 @@
         "@type": "BlogPosting",
         "headline": "Lørdag formiddag, og ingen har spurgt endnu",
         "alternativeHeadline": "Saturday morning, and no one's asked yet",
-        "url": "https://skalvilege.dk/blog/lordag-formiddag/",
+        "url": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/",
         "datePublished": "2026-04-20",
         "author": {
           "@type": "Organization",
@@ -57,10 +57,10 @@
   <meta name="theme-color" content="#2563eb">
   <link rel="icon" type="image/svg+xml" href="../assets/logo-no-background.svg">
   <link rel="apple-touch-icon" href="../assets/logo.png">
-  <link rel="alternate" hreflang="da" href="https://skalvilege.dk/blog/">
-  <link rel="alternate" hreflang="en" href="https://skalvilege.dk/blog/">
-  <link rel="alternate" hreflang="x-default" href="https://skalvilege.dk/blog/">
-  <link rel="alternate" type="application/rss+xml" title="Playdate Blog" href="/blog/feed.xml">
+  <link rel="alternate" hreflang="da" href="https://incubatordk.github.io/skalvilege.dk/blog/">
+  <link rel="alternate" hreflang="en" href="https://incubatordk.github.io/skalvilege.dk/blog/">
+  <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/blog/">
+  <link rel="alternate" type="application/rss+xml" title="Playdate Blog" href="feed.xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -70,20 +70,20 @@
 <body data-blog-page="index">
   <nav class="nav">
     <div class="nav-inner">
-      <a href="/" class="nav-logo" aria-label="Playdate">
+      <a href="../" class="nav-logo" aria-label="Playdate">
         <img src="../assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
       <ul class="nav-links">
-        <li><a href="/#features" data-blog-i18n="nav.features">Funktioner</a></li>
-        <li><a href="/#how-it-works" data-blog-i18n="nav.how">Sådan virker det</a></li>
-        <li><a href="/#founders" data-blog-i18n="nav.about">Om os</a></li>
-        <li><a href="/blog/" aria-current="page" data-blog-i18n="nav.blog">Blog</a></li>
+        <li><a href="../#features" data-blog-i18n="nav.features">Funktioner</a></li>
+        <li><a href="../#how-it-works" data-blog-i18n="nav.how">Sådan virker det</a></li>
+        <li><a href="../#founders" data-blog-i18n="nav.about">Om os</a></li>
+        <li><a href="./" aria-current="page" data-blog-i18n="nav.blog">Blog</a></li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">
           <span data-blog-i18n="lang.toggle">EN</span>
         </button>
-        <a href="/#cta" class="btn btn-primary btn-primary-sm" data-blog-i18n="nav.cta">Tilmeld venteliste →</a>
+        <a href="../#cta" class="btn btn-primary btn-primary-sm" data-blog-i18n="nav.cta">Tilmeld venteliste →</a>
       </div>
     </div>
   </nav>
@@ -100,14 +100,14 @@
     <section class="blog-list-section">
       <div class="container">
         <article class="blog-card">
-          <a href="/blog/lordag-formiddag/" class="blog-card-image" aria-label="Læs Lørdag formiddag, og ingen har spurgt endnu" data-blog-i18n-aria="blog.card.aria">
+          <a href="lordag-formiddag/" class="blog-card-image" aria-label="Læs Lørdag formiddag, og ingen har spurgt endnu" data-blog-i18n-aria="blog.card.aria">
             <img src="../assets/blog/playdate-19-04.jpg" alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale" data-blog-i18n-alt="blog.image.alt" width="1408" height="768">
           </a>
           <div class="blog-card-body">
             <p class="post-meta" data-blog-i18n="blog.post.date">20. april 2026 · Playdate</p>
-            <h2><a href="/blog/lordag-formiddag/" data-blog-i18n="blog.post.title">Lørdag formiddag, og ingen har spurgt endnu</a></h2>
+            <h2><a href="lordag-formiddag/" data-blog-i18n="blog.post.title">Lørdag formiddag, og ingen har spurgt endnu</a></h2>
             <p data-blog-i18n="blog.post.excerpt">Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.</p>
-            <a href="/blog/lordag-formiddag/" class="read-more" data-blog-i18n="blog.read">Læs artiklen</a>
+            <a href="lordag-formiddag/" class="read-more" data-blog-i18n="blog.read">Læs artiklen</a>
           </div>
         </article>
       </div>
@@ -119,9 +119,9 @@
       <div class="footer-bottom">
         <p data-blog-i18n="footer.copy">© 2026 Playdate. Alle rettigheder forbeholdes.</p>
         <div class="footer-links">
-          <a href="/privacy-policy/" data-blog-i18n="footer.privacy">Privatlivspolitik</a>
-          <a href="/terms.html" data-blog-i18n="footer.terms">Vilkår og betingelser</a>
-          <a href="/blog/" data-blog-i18n="nav.blog">Blog</a>
+          <a href="../privacy-policy/" data-blog-i18n="footer.privacy">Privatlivspolitik</a>
+          <a href="../terms.html" data-blog-i18n="footer.terms">Vilkår og betingelser</a>
+          <a href="./" data-blog-i18n="nav.blog">Blog</a>
         </div>
       </div>
     </div>

--- a/blog/lordag-formiddag/index.html
+++ b/blog/lordag-formiddag/index.html
@@ -5,24 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lørdag formiddag, og ingen har spurgt endnu — Playdate</title>
   <meta name="description" content="Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.">
-  <link rel="canonical" href="https://skalvilege.dk/blog/lordag-formiddag/">
+  <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
   <meta name="robots" content="index, follow">
 
   <meta property="og:title" content="Lørdag formiddag, og ingen har spurgt endnu — Playdate">
   <meta property="og:description" content="Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.">
   <meta property="og:type" content="article">
-  <meta property="og:url" content="https://skalvilege.dk/blog/lordag-formiddag/">
+  <meta property="og:url" content="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
   <meta property="og:site_name" content="Playdate">
   <meta property="og:locale" content="da_DK">
   <meta property="og:locale:alternate" content="en_GB">
   <meta property="article:published_time" content="2026-04-20T08:00:00+02:00">
   <meta property="article:author" content="Playdate">
-  <meta property="og:image" content="https://skalvilege.dk/assets/blog/playdate-19-04.jpg">
+  <meta property="og:image" content="https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Lørdag formiddag, og ingen har spurgt endnu — Playdate">
   <meta name="twitter:description" content="Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.">
-  <meta name="twitter:image" content="https://skalvilege.dk/assets/blog/playdate-19-04.jpg">
+  <meta name="twitter:image" content="https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg">
 
   <script type="application/ld+json">
   {
@@ -31,7 +31,7 @@
     "headline": "Lørdag formiddag, og ingen har spurgt endnu",
     "alternativeHeadline": "Saturday morning, and no one's asked yet",
     "description": "Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.",
-    "image": "https://skalvilege.dk/assets/blog/playdate-19-04.jpg",
+    "image": "https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg",
     "datePublished": "2026-04-20T08:00:00+02:00",
     "dateModified": "2026-04-20T08:00:00+02:00",
     "inLanguage": ["da", "en"],
@@ -44,10 +44,10 @@
       "name": "Playdate",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://skalvilege.dk/assets/logo-color.svg"
+        "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
       }
     },
-    "mainEntityOfPage": "https://skalvilege.dk/blog/lordag-formiddag/",
+    "mainEntityOfPage": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/",
     "isAccessibleForFree": true
   }
   </script>
@@ -55,10 +55,10 @@
   <meta name="theme-color" content="#2563eb">
   <link rel="icon" type="image/svg+xml" href="../../assets/logo-no-background.svg">
   <link rel="apple-touch-icon" href="../../assets/logo.png">
-  <link rel="alternate" hreflang="da" href="https://skalvilege.dk/blog/lordag-formiddag/">
-  <link rel="alternate" hreflang="en" href="https://skalvilege.dk/blog/lordag-formiddag/">
-  <link rel="alternate" hreflang="x-default" href="https://skalvilege.dk/blog/lordag-formiddag/">
-  <link rel="alternate" type="application/rss+xml" title="Playdate Blog" href="/blog/feed.xml">
+  <link rel="alternate" hreflang="da" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
+  <link rel="alternate" hreflang="en" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
+  <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
+  <link rel="alternate" type="application/rss+xml" title="Playdate Blog" href="../feed.xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -68,20 +68,20 @@
 <body data-blog-page="post">
   <nav class="nav">
     <div class="nav-inner">
-      <a href="/" class="nav-logo" aria-label="Playdate">
+      <a href="../../" class="nav-logo" aria-label="Playdate">
         <img src="../../assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
       <ul class="nav-links">
-        <li><a href="/#features" data-blog-i18n="nav.features">Funktioner</a></li>
-        <li><a href="/#how-it-works" data-blog-i18n="nav.how">Sådan virker det</a></li>
-        <li><a href="/#founders" data-blog-i18n="nav.about">Om os</a></li>
-        <li><a href="/blog/" aria-current="true" data-blog-i18n="nav.blog">Blog</a></li>
+        <li><a href="../../#features" data-blog-i18n="nav.features">Funktioner</a></li>
+        <li><a href="../../#how-it-works" data-blog-i18n="nav.how">Sådan virker det</a></li>
+        <li><a href="../../#founders" data-blog-i18n="nav.about">Om os</a></li>
+        <li><a href="../" aria-current="true" data-blog-i18n="nav.blog">Blog</a></li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">
           <span data-blog-i18n="lang.toggle">EN</span>
         </button>
-        <a href="/#cta" class="btn btn-primary btn-primary-sm" data-blog-i18n="nav.cta">Tilmeld venteliste →</a>
+        <a href="../../#cta" class="btn btn-primary btn-primary-sm" data-blog-i18n="nav.cta">Tilmeld venteliste →</a>
       </div>
     </div>
   </nav>
@@ -90,7 +90,7 @@
     <article class="post">
       <header class="post-header">
         <div class="container post-header-inner">
-          <a href="/blog/" class="back-link" data-blog-i18n="blog.back">Blog</a>
+          <a href="../" class="back-link" data-blog-i18n="blog.back">Blog</a>
           <p class="post-meta" data-blog-i18n="blog.post.date">20. april 2026 · Playdate</p>
           <h1 data-blog-i18n="blog.post.title">Lørdag formiddag, og ingen har spurgt endnu</h1>
           <p class="post-dek" data-blog-i18n="blog.post.dek">Om tærsklen for en lørdags-playdate, og hvorfor den er højere end den fortjener.</p>
@@ -145,9 +145,9 @@
       <div class="footer-bottom">
         <p data-blog-i18n="footer.copy">© 2026 Playdate. Alle rettigheder forbeholdes.</p>
         <div class="footer-links">
-          <a href="/privacy-policy/" data-blog-i18n="footer.privacy">Privatlivspolitik</a>
-          <a href="/terms.html" data-blog-i18n="footer.terms">Vilkår og betingelser</a>
-          <a href="/blog/" data-blog-i18n="nav.blog">Blog</a>
+          <a href="../../privacy-policy/" data-blog-i18n="footer.privacy">Privatlivspolitik</a>
+          <a href="../../terms.html" data-blog-i18n="footer.terms">Vilkår og betingelser</a>
+          <a href="../" data-blog-i18n="nav.blog">Blog</a>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Playdate — Din landsby i lommen</title>
   <meta name="description" content="Playdate er en ny app til danske og internationale familier, der gør det nemt at finde legekammerater og koordinere legeaftaler.">
-  <link rel="canonical" href="https://skalvilege.dk/">
+  <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/">
   <meta name="robots" content="index, follow">
   <meta name="keywords" content="playdate, legeaftale, legekammerater, børn, forældre, familie, app, Danmark, Copenhagen, København, expat">
 
@@ -13,17 +13,17 @@
   <meta property="og:title" content="Playdate — Din landsby i lommen">
   <meta property="og:description" content="En tryggere og enklere måde at arrangere legeaftaler for børn i alderen 0–10 år.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://skalvilege.dk/">
+  <meta property="og:url" content="https://incubatordk.github.io/skalvilege.dk/">
   <meta property="og:locale" content="da_DK">
   <meta property="og:locale:alternate" content="en_GB">
   <meta property="og:site_name" content="Playdate">
-  <meta property="og:image" content="https://skalvilege.dk/assets/logo.png">
+  <meta property="og:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Playdate — Din landsby i lommen">
   <meta name="twitter:description" content="En tryggere og enklere måde at arrangere legeaftaler for børn i alderen 0–10 år.">
-  <meta name="twitter:image" content="https://skalvilege.dk/assets/logo.png">
+  <meta name="twitter:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
 
   <!-- Structured Data -->
   <script type="application/ld+json">
@@ -31,13 +31,13 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "Playdate",
-    "url": "https://skalvilege.dk",
+    "url": "https://incubatordk.github.io/skalvilege.dk",
     "description": "A new app for Danish and international families to find playmates and coordinate playdates.",
     "applicationCategory": "LifestyleApplication",
     "operatingSystem": "iOS, Android",
     "inLanguage": ["da", "en"],
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "DKK" },
-    "author": { "@type": "Organization", "name": "Playdate", "url": "https://skalvilege.dk" }
+    "author": { "@type": "Organization", "name": "Playdate", "url": "https://incubatordk.github.io/skalvilege.dk" }
   }
   </script>
 
@@ -50,9 +50,9 @@
   <link rel="apple-touch-icon" href="assets/logo.png">
 
   <!-- i18n hreflang -->
-  <link rel="alternate" hreflang="da" href="https://skalvilege.dk/">
-  <link rel="alternate" hreflang="en" href="https://skalvilege.dk/">
-  <link rel="alternate" hreflang="x-default" href="https://skalvilege.dk/">
+  <link rel="alternate" hreflang="da" href="https://incubatordk.github.io/skalvilege.dk/">
+  <link rel="alternate" hreflang="en" href="https://incubatordk.github.io/skalvilege.dk/">
+  <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -74,7 +74,7 @@
         <li><a href="#features" data-i18n="nav.features">Funktioner</a></li>
         <li><a href="#how-it-works" data-i18n="nav.how">Sådan virker det</a></li>
         <li><a href="#founders" data-i18n="nav.about">Om os</a></li>
-        <li><a href="/blog/" data-i18n="nav.blog">Blog</a></li>
+        <li><a href="blog/" data-i18n="nav.blog">Blog</a></li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">
@@ -526,7 +526,7 @@
             <li><a href="#features" data-i18n="footer.features">Funktioner</a></li>
             <li><a href="#how-it-works" data-i18n="footer.how">Sådan virker det</a></li>
             <li><a href="#founders" data-i18n="footer.about2">Om os</a></li>
-            <li><a href="/blog/" data-i18n="footer.blog">Blog</a></li>
+            <li><a href="blog/" data-i18n="footer.blog">Blog</a></li>
           </ul>
         </div>
 
@@ -568,7 +568,7 @@
         <div class="footer-links" style="display: flex; gap: 24px;">
           <a href="privacy-policy/" data-i18n="footer.privacy">Privatlivspolitik</a>
           <a href="terms.html" data-i18n="footer.terms">Vilkår og betingelser</a>
-          <a href="/blog/" data-i18n="footer.blog">Blog</a>
+          <a href="blog/" data-i18n="footer.blog">Blog</a>
         </div>
         <p data-i18n="footer.built">Bygget med ❤️ af forældre, for forældre.</p>
       </div>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privatlivspolitik — Playdate</title>
   <meta name="description" content="Playdate privatlivspolitik.">
-  <link rel="canonical" href="https://skalvilege.dk/privacy-policy/">
+  <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/privacy-policy/">
   <meta name="robots" content="index, follow">
   <link rel="icon" type="image/svg+xml" href="../assets/logo-no-background.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -29,7 +29,7 @@
         <img src="../assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
       <ul class="nav-links">
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="../blog/">Blog</a></li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://skalvilege.dk/sitemap.xml
+Sitemap: https://incubatordk.github.io/skalvilege.dk/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://skalvilege.dk/</loc>
+    <loc>https://incubatordk.github.io/skalvilege.dk/</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://skalvilege.dk/privacy-policy/</loc>
+    <loc>https://incubatordk.github.io/skalvilege.dk/privacy-policy/</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://skalvilege.dk/terms.html</loc>
+    <loc>https://incubatordk.github.io/skalvilege.dk/terms.html</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://skalvilege.dk/blog/</loc>
+    <loc>https://incubatordk.github.io/skalvilege.dk/blog/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://skalvilege.dk/blog/lordag-formiddag/</loc>
+    <loc>https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/terms.html
+++ b/terms.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vilkår og betingelser — Playdate</title>
   <meta name="description" content="Playdate vilkår og betingelser.">
-  <link rel="canonical" href="https://skalvilege.dk/terms.html">
+  <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/terms.html">
   <meta name="robots" content="index, follow">
   <link rel="icon" type="image/svg+xml" href="assets/logo-no-background.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -28,7 +28,7 @@
         <img src="assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
       <ul class="nav-links">
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="blog/">Blog</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- Remove the premature custom-domain CNAME because the site currently deploys under https://incubatordk.github.io/skalvilege.dk/
- Update canonical, Open Graph, Twitter, sitemap, RSS and structured-data URLs to the current GitHub Pages project URL
- Keep internal blog navigation relative so links work under the /skalvilege.dk/ project path and later custom-domain deployment

## Verification
- Ran git diff --check
- Ran xmllint --noout sitemap.xml blog/feed.xml
- Ran node --check js/blog-i18n.js
- Checked local HTTP 200s for /blog/ and /blog/lordag-formiddag/