### PR TITLE
SEO + AI crawler optimization pass

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Siden findes ikke — Playdate</title>
+  <meta name="description" content="Den side, du leder efter, findes ikke længere — eller har måske aldrig gjort det. Find vej tilbage til Playdate.">
+  <meta name="robots" content="noindex, follow">
+  <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/404.html">
+
+  <meta property="og:title" content="Siden findes ikke — Playdate">
+  <meta property="og:description" content="Den side, du leder efter, findes ikke længere.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Playdate">
+  <meta property="og:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
+
+  <meta name="theme-color" content="#2563eb">
+  <link rel="icon" type="image/svg+xml" href="/skalvilege.dk/assets/logo-no-background.svg">
+  <link rel="apple-touch-icon" href="/skalvilege.dk/assets/logo.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500..900&family=Manrope:wght@400..800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/skalvilege.dk/css/styles.css">
+
+  <style>
+    .err {
+      min-height: 70vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4rem 1.5rem;
+      text-align: center;
+    }
+    .err-inner { max-width: 560px; margin: 0 auto; }
+    .err-code {
+      font-family: "Fraunces", Georgia, serif;
+      font-size: clamp(96px, 16vw, 180px);
+      font-weight: 800;
+      line-height: 1;
+      letter-spacing: -0.04em;
+      background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      margin: 0 0 1rem;
+    }
+    .err h1 {
+      font-family: "Fraunces", Georgia, serif;
+      font-size: clamp(28px, 4vw, 40px);
+      font-weight: 700;
+      margin: 0 0 0.75rem;
+    }
+    .err p { color: #475569; line-height: 1.6; margin: 0 0 2rem; }
+    .err-actions { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+  </style>
+
+  <script defer src="https://umami.robert-jensen.dk/script.js" data-website-id="753c9cee-5711-43ba-91a1-be2531471bd2"></script>
+</head>
+<body>
+
+  <nav class="nav">
+    <div class="nav-inner">
+      <a href="/skalvilege.dk/" class="nav-logo" aria-label="Playdate">
+        <img src="/skalvilege.dk/assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
+      </a>
+      <ul class="nav-links">
+        <li><a href="/skalvilege.dk/#features">Funktioner</a></li>
+        <li><a href="/skalvilege.dk/#how-it-works">Sådan virker det</a></li>
+        <li><a href="/skalvilege.dk/blog/">Blog</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="err">
+    <div class="err-inner">
+      <p class="err-code">404</p>
+      <h1>Siden findes ikke</h1>
+      <p>Den side, du leder efter, findes ikke længere — eller har måske aldrig gjort det. Måske er linket forældet, eller adressen er skrevet forkert.</p>
+      <div class="err-actions">
+        <a href="/skalvilege.dk/" class="btn btn-primary">← Tilbage til forsiden</a>
+        <a href="/skalvilege.dk/blog/" class="btn btn-outline">Læs bloggen</a>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Playdate Blog</title>
     <link>https://incubatordk.github.io/skalvilege.dk/blog/</link>
@@ -18,8 +21,28 @@
       <link>https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/</link>
       <guid isPermaLink="true">https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/</guid>
       <pubDate>Mon, 20 Apr 2026 06:00:00 +0000</pubDate>
+      <dc:creator>Playdate</dc:creator>
       <author>playdate@skalvilege.dk (Playdate)</author>
+      <category>Familieliv</category>
       <description>Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.</description>
+      <content:encoded><![CDATA[
+        <p><img src="https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg" alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale" /></p>
+        <p>Lørdag kvart over ni. Et barn sidder på gulvet med en bunke LEGO, kigger op og spørger: "Skal vi lege med nogen i dag?"</p>
+        <p>Forælderen tænker på, hvem der kunne skrives til.</p>
+        <p>Der er tre-fire familier, hvis børn det rigtig gerne må være. Numrene ligger i telefonen. Et par af dem måske endda på WhatsApp. Men spørgsmålet sidder fast et sted mellem "det er vel også lidt sent at skrive nu" og "de har sikkert allerede planer" og den lille tøven ved at skrive til én specifik forælder, når det lige så godt kunne være en anden familie, der havde en rolig formiddag.</p>
+        <p>Beskeden bliver ikke sendt. Barnet sender den heller ikke selv, for det er fire år gammelt.</p>
+        <p>Klokken bliver elleve. Klokken bliver halv tolv. Det bliver til frokost derhjemme og en tur i nærmeste park, hvor ingen kendte dukker op. Alt er fint. Men det, barnet faktisk spurgte om klokken ni, skete ikke.</p>
+        <p>Det her er det problem, Skal vi lege? blev lavet til.</p>
+        <p>Det er ikke et helt bookingsystem eller en ny kalender, der skal vedligeholdes. Bare et sted, hvor man som forælder kan lægge op, at man er hjemme lørdag fra ti til tolv, at man har en fireårig, der elsker at bygge LEGO, og at man gerne tager imod. Og så ser man, hvem der melder sig.</p>
+        <p>Det er den måde, playdates bliver til, når det lykkes: en tråd i en mor-gruppe på Facebook, en kort besked, et tilfældigt møde i børnehaven. Det er bare ikke den måde, det lykkes om lørdagen, når planen er "vi ser, hvordan dagen udvikler sig."</p>
+        <p>Problemet er ikke viljen. Det er tærsklen.</p>
+        <p>At skrive til én specifik forælder lørdag formiddag er en større handling end den fortjener. Det føles som at invitere til selskab. At lægge op, at man er hjemme og åben, er nul. Det kræver ikke, at nogen skal sige nej. Det kræver ikke, at man vælger, hvem man spørger først.</p>
+        <p>For forældrene betyder det, at lørdag formiddag ikke længere er en pause, hvor ingen skriver. For barnet betyder det, at spørgsmålet faktisk bliver besvaret.</p>
+        <p>Vi har tænkt en hel del over, hvad app'en skal gøre for at være tryg: verificerede profiler, billeder af børn beskyttet som standard, ingen telefonnumre der deles automatisk. Det handler ikke om at gøre folk bange for noget, der ikke er der. Det handler om, at man skal kunne sige ja til en playdate på tværs af familier uden at give private oplysninger væk i et opslag. Det er en praktisk del af, at det overhovedet fungerer.</p>
+        <p>Men den vigtigste del er stadig den enkle.</p>
+        <p>Barnet spørger: "Skal vi lege?" Og om lørdagen klokken kvart over ni er der faktisk et sted, hvor man kan få svaret.</p>
+        <p>Danske fireårige lærer det tidligt: at spørgsmålet findes. Arbejdet, for de voksne, er at blive lige så gode til at stille det.</p>
+      ]]></content:encoded>
     </item>
   </channel>
 </rss>

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,30 +25,41 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Blog",
-    "name": "Playdate Blog",
-    "description": "Fortællinger og noter om legeaftaler, børneliv og de små sociale tærskler i familielivet.",
-    "url": "https://incubatordk.github.io/skalvilege.dk/blog/",
-    "inLanguage": ["da", "en"],
-    "publisher": {
-      "@type": "Organization",
-      "name": "Playdate",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
-      }
-    },
-    "blogPost": [
+    "@graph": [
       {
-        "@type": "BlogPosting",
-        "headline": "Lørdag formiddag, og ingen har spurgt endnu",
-        "alternativeHeadline": "Saturday morning, and no one's asked yet",
-        "url": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/",
-        "datePublished": "2026-04-20",
-        "author": {
+        "@type": "Blog",
+        "name": "Playdate Blog",
+        "description": "Fortællinger og noter om legeaftaler, børneliv og de små sociale tærskler i familielivet.",
+        "url": "https://incubatordk.github.io/skalvilege.dk/blog/",
+        "inLanguage": ["da", "en"],
+        "publisher": {
           "@type": "Organization",
-          "name": "Playdate"
-        }
+          "name": "Playdate",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
+          }
+        },
+        "blogPost": [
+          {
+            "@type": "BlogPosting",
+            "headline": "Lørdag formiddag, og ingen har spurgt endnu",
+            "alternativeHeadline": "Saturday morning, and no one's asked yet",
+            "url": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/",
+            "datePublished": "2026-04-20",
+            "author": {
+              "@type": "Organization",
+              "name": "Playdate"
+            }
+          }
+        ]
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Playdate", "item": "https://incubatordk.github.io/skalvilege.dk/" },
+          { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://incubatordk.github.io/skalvilege.dk/blog/" }
+        ]
       }
     ]
   }
@@ -57,8 +68,7 @@
   <meta name="theme-color" content="#2563eb">
   <link rel="icon" type="image/svg+xml" href="../assets/logo-no-background.svg">
   <link rel="apple-touch-icon" href="../assets/logo.png">
-  <link rel="alternate" hreflang="da" href="https://incubatordk.github.io/skalvilege.dk/blog/">
-  <link rel="alternate" hreflang="en" href="https://incubatordk.github.io/skalvilege.dk/blog/">
+  <link rel="manifest" href="../manifest.webmanifest">
   <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/blog/">
   <link rel="alternate" type="application/rss+xml" title="Playdate Blog" href="feed.xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -101,7 +111,7 @@
       <div class="container">
         <article class="blog-card">
           <a href="lordag-formiddag/" class="blog-card-image" aria-label="Læs Lørdag formiddag, og ingen har spurgt endnu" data-blog-i18n-aria="blog.card.aria">
-            <img src="../assets/blog/playdate-19-04.jpg" alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale" data-blog-i18n-alt="blog.image.alt" width="1408" height="768">
+            <img src="../assets/blog/playdate-19-04.jpg" alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale" data-blog-i18n-alt="blog.image.alt" width="1408" height="768" loading="lazy" decoding="async">
           </a>
           <div class="blog-card-body">
             <p class="post-meta" data-blog-i18n="blog.post.date">20. april 2026 · Playdate</p>

--- a/blog/lordag-formiddag/index.html
+++ b/blog/lordag-formiddag/index.html
@@ -27,36 +27,49 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "BlogPosting",
-    "headline": "Lørdag formiddag, og ingen har spurgt endnu",
-    "alternativeHeadline": "Saturday morning, and no one's asked yet",
-    "description": "Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.",
-    "image": "https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg",
-    "datePublished": "2026-04-20T08:00:00+02:00",
-    "dateModified": "2026-04-20T08:00:00+02:00",
-    "inLanguage": ["da", "en"],
-    "author": {
-      "@type": "Organization",
-      "name": "Playdate"
-    },
-    "publisher": {
-      "@type": "Organization",
-      "name": "Playdate",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
+    "@graph": [
+      {
+        "@type": "BlogPosting",
+        "headline": "Lørdag formiddag, og ingen har spurgt endnu",
+        "alternativeHeadline": "Saturday morning, and no one's asked yet",
+        "description": "Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.",
+        "image": "https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg",
+        "datePublished": "2026-04-20T08:00:00+02:00",
+        "dateModified": "2026-04-20T08:00:00+02:00",
+        "inLanguage": ["da", "en"],
+        "author": {
+          "@type": "Organization",
+          "name": "Playdate"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Playdate",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
+          }
+        },
+        "mainEntityOfPage": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/",
+        "isAccessibleForFree": true,
+        "wordCount": 480,
+        "articleSection": "Familieliv"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Playdate", "item": "https://incubatordk.github.io/skalvilege.dk/" },
+          { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://incubatordk.github.io/skalvilege.dk/blog/" },
+          { "@type": "ListItem", "position": 3, "name": "Lørdag formiddag, og ingen har spurgt endnu", "item": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/" }
+        ]
       }
-    },
-    "mainEntityOfPage": "https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/",
-    "isAccessibleForFree": true
+    ]
   }
   </script>
 
   <meta name="theme-color" content="#2563eb">
   <link rel="icon" type="image/svg+xml" href="../../assets/logo-no-background.svg">
   <link rel="apple-touch-icon" href="../../assets/logo.png">
-  <link rel="alternate" hreflang="da" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
-  <link rel="alternate" hreflang="en" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
+  <link rel="manifest" href="../../manifest.webmanifest">
   <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/">
   <link rel="alternate" type="application/rss+xml" title="Playdate Blog" href="../feed.xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -98,7 +111,7 @@
       </header>
 
       <figure class="post-hero-image">
-        <img src="../../assets/blog/playdate-19-04.jpg" alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale" data-blog-i18n-alt="blog.image.alt" width="1408" height="768">
+        <img src="../../assets/blog/playdate-19-04.jpg" alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale" data-blog-i18n-alt="blog.image.alt" width="1408" height="768" fetchpriority="high" decoding="async">
       </figure>
 
       <div class="post-content" data-blog-lang="da">

--- a/index.html
+++ b/index.html
@@ -29,15 +29,94 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebApplication",
-    "name": "Playdate",
-    "url": "https://incubatordk.github.io/skalvilege.dk",
-    "description": "A new app for Danish and international families to find playmates and coordinate playdates.",
-    "applicationCategory": "LifestyleApplication",
-    "operatingSystem": "iOS, Android",
-    "inLanguage": ["da", "en"],
-    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "DKK" },
-    "author": { "@type": "Organization", "name": "Playdate", "url": "https://incubatordk.github.io/skalvilege.dk" }
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://incubatordk.github.io/skalvilege.dk/#organization",
+        "name": "Playdate",
+        "url": "https://incubatordk.github.io/skalvilege.dk/",
+        "logo": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg",
+        "email": "playdate@skalvilege.dk",
+        "areaServed": { "@type": "Country", "name": "Denmark" },
+        "founder": [
+          { "@type": "Person", "name": "Jinhong Brejnholt", "sameAs": "https://www.linkedin.com/in/jbrejnholt/" },
+          { "@type": "Person", "name": "Jimmi Hested", "sameAs": "https://www.linkedin.com/in/jhested/" },
+          { "@type": "Person", "name": "Robert Jensen", "sameAs": "https://www.linkedin.com/in/robert-jensen-devops/" }
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://incubatordk.github.io/skalvilege.dk/#website",
+        "url": "https://incubatordk.github.io/skalvilege.dk/",
+        "name": "Playdate",
+        "publisher": { "@id": "https://incubatordk.github.io/skalvilege.dk/#organization" },
+        "inLanguage": ["da-DK", "en-GB"]
+      },
+      {
+        "@type": "WebApplication",
+        "name": "Playdate",
+        "url": "https://incubatordk.github.io/skalvilege.dk/",
+        "description": "A new app for Danish and international families to find playmates and coordinate playdates for children aged 0–10.",
+        "applicationCategory": "LifestyleApplication",
+        "operatingSystem": "iOS, Android",
+        "inLanguage": ["da", "en"],
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "DKK" },
+        "publisher": { "@id": "https://incubatordk.github.io/skalvilege.dk/#organization" }
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Hvad er Playdate?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Playdate er en ny app til danske og internationale familier, der gør det nemt at finde legekammerater og koordinere legeaftaler for børn i alderen 0–10 år."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Hvem kan bruge Playdate?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Forældre i Danmark — både danske familier og internationale, der slår sig ned her. Appen er fuldt tosproget på dansk og engelsk."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Hvordan virker det?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Opret en familieprofil, find nærliggende eller forbundne familier på et interaktivt kort, og send en invitation til en legeaftale. Når den er bekræftet, sendes påmindelser automatisk."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Hvor sikker er Playdate?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Alle profiler er verificeret. Børns billeder er privatlivsbeskyttede, indtil familier er gensidigt forbundet, og telefonnumre deles aldrig automatisk."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Hvad koster det?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Det er gratis at tilmelde sig ventelisten. Appen lancerer i Danmark."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Kan jeg bruge Playdate på ferien?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ja. Ferietilstand lader jer finde legekammerater i Lalandia, Center Parcs eller hvor som helst i Danmark, mens I er afsted."
+            }
+          }
+        ]
+      }
+    ]
   }
   </script>
 
@@ -48,10 +127,9 @@
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="assets/logo-no-background.svg">
   <link rel="apple-touch-icon" href="assets/logo.png">
+  <link rel="manifest" href="manifest.webmanifest">
 
-  <!-- i18n hreflang -->
-  <link rel="alternate" hreflang="da" href="https://incubatordk.github.io/skalvilege.dk/">
-  <link rel="alternate" hreflang="en" href="https://incubatordk.github.io/skalvilege.dk/">
+  <!-- i18n hreflang — single URL serves both languages via JS toggle -->
   <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/">
 
   <!-- Fonts -->
@@ -165,7 +243,7 @@
                   <p>Sarah &amp; Leo 🦁</p>
                 </div>
                 <div class="phone-avatar">
-                  <img src="assets/profile_oliver_mom.png" alt="">
+                  <img src="assets/profile_oliver_mom.png" alt="" loading="lazy" decoding="async" width="40" height="40">
                 </div>
               </div>
 
@@ -175,7 +253,7 @@
                   <p class="phone-card-label">Next Playdate</p>
                   <div class="phone-row">
                     <div class="phone-pic">
-                      <img src="assets/profile_noah.png" alt="Noah">
+                      <img src="assets/profile_noah.png" alt="Noah" loading="lazy" decoding="async" width="48" height="48">
                     </div>
                     <div>
                       <p class="phone-name">Noah &amp; Magnus</p>
@@ -199,7 +277,7 @@
 
                 <div class="phone-suggestion">
                   <div class="phone-pic phone-pic-sm">
-                    <img src="assets/profile_oliver.png" alt="Oliver">
+                    <img src="assets/profile_oliver.png" alt="Oliver" loading="lazy" decoding="async" width="40" height="40">
                   </div>
                   <div class="phone-suggestion-body">
                     <p>Oliver (6)</p>
@@ -212,7 +290,7 @@
 
                 <div class="phone-suggestion">
                   <div class="phone-pic phone-pic-sm">
-                    <img src="assets/profile_emma.png" alt="Emma">
+                    <img src="assets/profile_emma.png" alt="Emma" loading="lazy" decoding="async" width="40" height="40">
                   </div>
                   <div class="phone-suggestion-body">
                     <p>Emma (7)</p>
@@ -357,7 +435,7 @@
             <div class="stars" aria-label="5 out of 5 stars">★★★★★</div>
             <p data-i18n="test.1">"Finally an app..."</p>
             <div class="testimonial-author">
-              <div class="avatar"><img src="assets/profile_oliver_mom.png" alt=""></div>
+              <div class="avatar"><img src="assets/profile_oliver_mom.png" alt="" loading="lazy" decoding="async" width="40" height="40"></div>
               <div>
                 <p class="testimonial-name" data-i18n="test.1.name">Sarah M.</p>
                 <p class="testimonial-meta" data-i18n="test.1.meta">Copenhagen · 2 kids</p>
@@ -369,7 +447,7 @@
             <div class="stars" aria-label="5 out of 5 stars">★★★★★</div>
             <p data-i18n="test.2">"We moved from the UK..."</p>
             <div class="testimonial-author">
-              <div class="avatar"><img src="assets/profile_sophie_dad.png" alt=""></div>
+              <div class="avatar"><img src="assets/profile_sophie_dad.png" alt="" loading="lazy" decoding="async" width="40" height="40"></div>
               <div>
                 <p class="testimonial-name" data-i18n="test.2.name">James T.</p>
                 <p class="testimonial-meta" data-i18n="test.2.meta">Aarhus · Expat family</p>
@@ -403,7 +481,7 @@
         <div class="founders-grid">
           <div class="founder" data-animate data-animate-delay="1">
             <div class="founder-head">
-              <div class="founder-pic"><img src="assets/jinhong_brejnholt.png" alt="Jinhong"></div>
+              <div class="founder-pic"><img src="assets/jinhong_brejnholt.png" alt="Jinhong Brejnholt" loading="lazy" decoding="async" width="80" height="80"></div>
               <div>
                 <a href="https://www.linkedin.com/in/jbrejnholt/" target="_blank" rel="noopener noreferrer" class="founder-name">Jinhong</a>
                 <p class="founder-role" data-i18n="founder.jinhong.role">Founder, Bitecloud</p>
@@ -414,7 +492,7 @@
 
           <div class="founder" data-animate data-animate-delay="2">
             <div class="founder-head">
-              <div class="founder-pic"><img src="assets/jimmi_hested.png" alt="Jimmi"></div>
+              <div class="founder-pic"><img src="assets/jimmi_hested.png" alt="Jimmi Hested" loading="lazy" decoding="async" width="80" height="80"></div>
               <div>
                 <a href="https://www.linkedin.com/in/jhested/" target="_blank" rel="noopener noreferrer" class="founder-name">Jimmi</a>
                 <p class="founder-role" data-i18n="founder.jimmi.role">Principal Engineer</p>
@@ -425,7 +503,7 @@
 
           <div class="founder" data-animate data-animate-delay="3">
             <div class="founder-head">
-              <div class="founder-pic"><img src="assets/robert_jensen.jpeg" alt="Robert"></div>
+              <div class="founder-pic"><img src="assets/robert_jensen.jpeg" alt="Robert Jensen" loading="lazy" decoding="async" width="80" height="80"></div>
               <div>
                 <a href="https://www.linkedin.com/in/robert-jensen-devops/" target="_blank" rel="noopener noreferrer" class="founder-name">Robert</a>
                 <p class="founder-role" data-i18n="founder.robert.role">DevOps Consultant</p>
@@ -523,7 +601,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-brand">
-          <img src="assets/logo-color.svg" alt="Playdate">
+          <img src="assets/logo-color.svg" alt="Playdate" loading="lazy" decoding="async" width="120" height="40">
           <p data-i18n="footer.about">Gør koordinering af legeaftaler ubesværet.</p>
         </div>
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,30 @@
+# Playdate
+
+> Playdate (skalvilege.dk) is a mobile app for Danish and international families that makes it easier to find playmates and arrange playdates for children aged 0–10. The site is the public landing page and waitlist for the prelaunch in Denmark.
+
+The product is built around a simple idea: most parents already know which families they'd like their kids to play with, but the threshold for actually arranging it is too high. Playdate lowers that threshold with verified profiles, an availability-aware calendar, an interactive map of nearby families, in-app messaging, and a holiday mode that finds playmates wherever a family travels in Denmark. The app is fully bilingual (Danish + English).
+
+The site is a single static landing page (Danish content with a JS language toggle to English) plus a small blog and standard legal pages. It is hosted on GitHub Pages at `incubatordk.github.io/skalvilege.dk`.
+
+## Pages
+
+- [Home](https://incubatordk.github.io/skalvilege.dk/): Product overview, features, how it works, founders, waitlist signup
+- [Blog](https://incubatordk.github.io/skalvilege.dk/blog/): Notes on playdates, parenting, family life
+- [Privacy policy](https://incubatordk.github.io/skalvilege.dk/privacy-policy/): Danish GDPR-compliant privacy policy
+- [Terms](https://incubatordk.github.io/skalvilege.dk/terms.html): Terms of service
+
+## Blog posts
+
+- [Lørdag formiddag, og ingen har spurgt endnu](https://incubatordk.github.io/skalvilege.dk/blog/lordag-formiddag/): Bilingual essay (Danish + English) on the threshold for arranging a Saturday-morning playdate, and why an "I'm home and open" post is a smaller ask than messaging one specific parent.
+
+## Feeds
+
+- [Blog RSS](https://incubatordk.github.io/skalvilege.dk/blog/feed.xml)
+- [Sitemap](https://incubatordk.github.io/skalvilege.dk/sitemap.xml)
+
+## About
+
+- Founders: Jinhong Brejnholt (cloud-native executive, founder of Bitecloud), Jimmi Hested (principal engineer), Robert Jensen (DevOps consultant). All are parents based in Denmark.
+- Status: Prelaunch — waitlist open, app not yet shipped on App Store / Google Play.
+- Target market: Denmark (Danish + English-speaking expat families), children aged 0–10.
+- Contact: playdate@skalvilege.dk

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,27 @@
+{
+  "name": "Playdate — Din landsby i lommen",
+  "short_name": "Playdate",
+  "description": "En tryggere og enklere måde at arrangere legeaftaler for børn i alderen 0–10 år.",
+  "start_url": "/skalvilege.dk/",
+  "scope": "/skalvilege.dk/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#ffffff",
+  "theme_color": "#2563eb",
+  "lang": "da-DK",
+  "categories": ["lifestyle", "social", "parenting"],
+  "icons": [
+    {
+      "src": "/skalvilege.dk/assets/logo-no-background.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/skalvilege.dk/assets/logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -4,9 +4,49 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privatlivspolitik — Playdate</title>
-  <meta name="description" content="Playdate privatlivspolitik.">
+  <meta name="description" content="Sådan håndterer Playdate dine personoplysninger: hvilke data vi indsamler, hvorfor, hvordan vi beskytter dem, og dine rettigheder under GDPR.">
   <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/privacy-policy/">
   <meta name="robots" content="index, follow">
+
+  <meta property="og:title" content="Privatlivspolitik — Playdate">
+  <meta property="og:description" content="Sådan håndterer Playdate dine personoplysninger: hvilke data vi indsamler, hvorfor, hvordan vi beskytter dem, og dine rettigheder under GDPR.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://incubatordk.github.io/skalvilege.dk/privacy-policy/">
+  <meta property="og:locale" content="da_DK">
+  <meta property="og:site_name" content="Playdate">
+  <meta property="og:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Privatlivspolitik — Playdate">
+  <meta name="twitter:description" content="Sådan håndterer Playdate dine personoplysninger.">
+  <meta name="twitter:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
+
+  <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/privacy-policy/">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "PrivacyPolicy",
+    "name": "Playdate privatlivspolitik",
+    "url": "https://incubatordk.github.io/skalvilege.dk/privacy-policy/",
+    "inLanguage": "da-DK",
+    "dateModified": "2026-04-17",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "Playdate",
+      "url": "https://incubatordk.github.io/skalvilege.dk/"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Playdate",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
+      }
+    }
+  }
+  </script>
+
   <link rel="icon" type="image/svg+xml" href="../assets/logo-no-background.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,65 @@
+# skalvilege.dk — robots.txt
+# Marketing landing page for Playdate (prelaunch). All content is public and may be indexed.
+
 User-agent: *
+Allow: /
+
+# --- AI / LLM crawlers ---
+# Explicitly welcome — this is a marketing site and we want it discoverable
+# by AI assistants for queries about Playdate, the founders, and the product.
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: Diffbot
 Allow: /
 
 Sitemap: https://incubatordk.github.io/skalvilege.dk/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://incubatordk.github.io/skalvilege.dk/</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+    <image:image>
+      <image:loc>https://incubatordk.github.io/skalvilege.dk/assets/logo.png</image:loc>
+      <image:title>Playdate</image:title>
+    </image:image>
   </url>
   <url>
     <loc>https://incubatordk.github.io/skalvilege.dk/privacy-policy/</loc>
@@ -29,5 +34,10 @@
     <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://incubatordk.github.io/skalvilege.dk/assets/blog/playdate-19-04.jpg</image:loc>
+      <image:title>Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale</image:title>
+      <image:caption>Lørdag formiddag, og ingen har spurgt endnu — om tærsklen for en lørdags-playdate.</image:caption>
+    </image:image>
   </url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -4,9 +4,49 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vilkår og betingelser — Playdate</title>
-  <meta name="description" content="Playdate vilkår og betingelser.">
+  <meta name="description" content="Vilkår for brug af Playdate-appen og skalvilege.dk: brugerkrav, acceptabel adfærd, ansvar og opsigelse.">
   <link rel="canonical" href="https://incubatordk.github.io/skalvilege.dk/terms.html">
   <meta name="robots" content="index, follow">
+
+  <meta property="og:title" content="Vilkår og betingelser — Playdate">
+  <meta property="og:description" content="Vilkår for brug af Playdate-appen og skalvilege.dk.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://incubatordk.github.io/skalvilege.dk/terms.html">
+  <meta property="og:locale" content="da_DK">
+  <meta property="og:site_name" content="Playdate">
+  <meta property="og:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Vilkår og betingelser — Playdate">
+  <meta name="twitter:description" content="Vilkår for brug af Playdate-appen og skalvilege.dk.">
+  <meta name="twitter:image" content="https://incubatordk.github.io/skalvilege.dk/assets/logo.png">
+
+  <link rel="alternate" hreflang="x-default" href="https://incubatordk.github.io/skalvilege.dk/terms.html">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Vilkår og betingelser — Playdate",
+    "url": "https://incubatordk.github.io/skalvilege.dk/terms.html",
+    "inLanguage": "da-DK",
+    "dateModified": "2026-04-17",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "Playdate",
+      "url": "https://incubatordk.github.io/skalvilege.dk/"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Playdate",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://incubatordk.github.io/skalvilege.dk/assets/logo-color.svg"
+      }
+    }
+  }
+  </script>
+
   <link rel="icon" type="image/svg+xml" href="assets/logo-no-background.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- New `llms.txt`, `404.html`, `manifest.webmanifest`
- `robots.txt` now explicitly allows 18 AI crawlers (GPTBot, ClaudeBot, anthropic-ai, Google-Extended, PerplexityBot, CCBot, Applebot-Extended, …)
- Expanded JSON-LD: Organization (with founder LinkedIn `sameAs`), WebSite, WebApplication, FAQPage on home; BreadcrumbList + wordCount on blog; PrivacyPolicy/WebPage on legal pages
- Added missing OG + Twitter cards to privacy + terms pages
- `loading=lazy` / `decoding=async` on below-fold images, `fetchpriority=high` on blog hero
- Image sitemap extension, full `content:encoded` in blog RSS
- Simplified hreflang to `x-default` only (single-URL JS-toggled site)

Closes #7

## Test plan
- [x] All 5 JSON-LD blocks parse as valid JSON
- [x] sitemap.xml + feed.xml parse as valid XML
- [x] manifest.webmanifest parses as valid JSON
- [x] Local server: `/llms.txt`, `/robots.txt`, `/manifest.webmanifest` (Content-Type: application/manifest+json), and 404 path all serve correctly
- [ ] After merge: GitHub Pages picks up `404.html`, sitemap reachable at canonical URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)