### PR TITLE
Surface blog on homepage: mobile menu + teaser section

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -83,17 +83,25 @@
       <a href="../" class="nav-logo" aria-label="Playdate">
         <img src="../assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
-      <ul class="nav-links">
+      <ul id="nav-menu" class="nav-links">
         <li><a href="../#features" data-blog-i18n="nav.features">Funktioner</a></li>
         <li><a href="../#how-it-works" data-blog-i18n="nav.how">Sådan virker det</a></li>
         <li><a href="../#founders" data-blog-i18n="nav.about">Om os</a></li>
         <li><a href="./" aria-current="page" data-blog-i18n="nav.blog">Blog</a></li>
+        <li class="nav-links-cta"><a href="../#cta" data-blog-i18n="nav.cta">Tilmeld venteliste →</a></li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">
           <span data-blog-i18n="lang.toggle">EN</span>
         </button>
         <a href="../#cta" class="btn btn-primary btn-primary-sm" data-blog-i18n="nav.cta">Tilmeld venteliste →</a>
+        <button id="nav-toggle" class="nav-toggle" type="button"
+                aria-label="Menu" aria-expanded="false" aria-controls="nav-menu"
+                data-blog-i18n-aria="nav.menu">
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+        </button>
       </div>
     </div>
   </nav>

--- a/blog/lordag-formiddag/index.html
+++ b/blog/lordag-formiddag/index.html
@@ -84,17 +84,25 @@
       <a href="../../" class="nav-logo" aria-label="Playdate">
         <img src="../../assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
-      <ul class="nav-links">
+      <ul id="nav-menu" class="nav-links">
         <li><a href="../../#features" data-blog-i18n="nav.features">Funktioner</a></li>
         <li><a href="../../#how-it-works" data-blog-i18n="nav.how">Sådan virker det</a></li>
         <li><a href="../../#founders" data-blog-i18n="nav.about">Om os</a></li>
         <li><a href="../" aria-current="true" data-blog-i18n="nav.blog">Blog</a></li>
+        <li class="nav-links-cta"><a href="../../#cta" data-blog-i18n="nav.cta">Tilmeld venteliste →</a></li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">
           <span data-blog-i18n="lang.toggle">EN</span>
         </button>
         <a href="../../#cta" class="btn btn-primary btn-primary-sm" data-blog-i18n="nav.cta">Tilmeld venteliste →</a>
+        <button id="nav-toggle" class="nav-toggle" type="button"
+                aria-label="Menu" aria-expanded="false" aria-controls="nav-menu"
+                data-blog-i18n-aria="nav.menu">
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+        </button>
       </div>
     </div>
   </nav>

--- a/css/styles.css
+++ b/css/styles.css
@@ -353,6 +353,10 @@ button {
   gap: var(--space-sm);
 }
 
+.nav-actions .btn {
+  display: none;
+}
+
 .lang-toggle {
   display: inline-flex;
   align-items: center;
@@ -378,6 +382,87 @@ button {
 
 .lang-toggle:active {
   transform: scale(0.96);
+}
+
+/* Hamburger — visible on mobile only (toggled off at ≥768px below) */
+.nav-toggle {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  background: transparent;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+}
+
+.nav-toggle:hover {
+  border-color: var(--color-primary);
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 2px;
+  transition: transform var(--transition-fast), opacity var(--transition-fast);
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(2) {
+  opacity: 0;
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+/* Mobile menu: when toggle open, show the links as a dropdown panel */
+.nav[data-menu-open="true"] .nav-links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: var(--space-lg);
+  background: #fff;
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+}
+
+.nav[data-menu-open="true"] .nav-links-cta {
+  margin-top: var(--space-sm);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--color-border);
+}
+
+.nav[data-menu-open="true"] .nav-links-cta a {
+  display: inline-block;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: var(--radius-md);
+  font-weight: 700;
+}
+
+.nav[data-menu-open="true"] .nav-links a {
+  display: block;
+  padding: var(--space-sm) 0;
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text);
 }
 
 /* ==========================================================================
@@ -1273,14 +1358,30 @@ button {
   object-fit: cover;
 }
 
-.blog-card-body h2 {
+.blog-card-body h2,
+.blog-card-body h3 {
   margin-bottom: var(--space-sm);
   font-size: var(--text-3xl);
   line-height: 1.16;
 }
 
-.blog-card-body h2 a {
+.blog-card-body h2 a,
+.blog-card-body h3 a {
   color: var(--color-text);
+}
+
+/* Homepage blog teaser */
+.blog-home {
+  padding: var(--space-3xl) 0;
+}
+
+.blog-home .section-header {
+  margin-bottom: var(--space-2xl);
+}
+
+.blog-home-cta {
+  margin-top: var(--space-xl);
+  text-align: center;
 }
 
 .blog-card-body p:not(.post-meta) {
@@ -1931,6 +2032,18 @@ button {
 
   .nav-links {
     display: flex;
+  }
+
+  .nav-links-cta {
+    display: none;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+
+  .nav-actions .btn {
+    display: inline-flex;
   }
 
   .blog-card {

--- a/index.html
+++ b/index.html
@@ -151,11 +151,15 @@
       <a href="#home" class="nav-logo" aria-label="Playdate">
         <img src="assets/logo-no-background.svg" alt="Playdate" width="36" height="36">
       </a>
-      <ul class="nav-links">
+      <ul id="nav-menu" class="nav-links">
         <li><a href="#features" data-i18n="nav.features">Funktioner</a></li>
         <li><a href="#how-it-works" data-i18n="nav.how">Sådan virker det</a></li>
         <li><a href="#founders" data-i18n="nav.about">Om os</a></li>
         <li><a href="blog/" data-i18n="nav.blog">Blog</a></li>
+        <li class="nav-links-cta">
+          <a href="#cta" data-mode-only="prelaunch" data-i18n="nav.cta">Tilmeld venteliste →</a>
+          <a href="#cta" class="hidden" data-mode-only="launched" data-i18n="nav.ctaLaunched">Download →</a>
+        </li>
       </ul>
       <div class="nav-actions">
         <button id="lang-toggle" class="lang-toggle" type="button" aria-label="Switch language">
@@ -163,6 +167,13 @@
         </button>
         <a href="#cta" class="btn btn-primary btn-primary-sm" data-mode-only="prelaunch" data-i18n="nav.cta">Tilmeld venteliste →</a>
         <a href="#cta" class="btn btn-primary btn-primary-sm hidden" data-mode-only="launched" data-i18n="nav.ctaLaunched">Download →</a>
+        <button id="nav-toggle" class="nav-toggle" type="button"
+                aria-label="Menu" aria-expanded="false" aria-controls="nav-menu"
+                data-i18n-aria="nav.menu">
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+        </button>
       </div>
     </div>
   </nav>
@@ -516,6 +527,38 @@
         <div class="mission" data-animate>
           <h3 data-i18n="mission.title">Vores mission</h3>
           <p data-i18n="mission.text">Hvert barn fortjener...</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Blog teaser -->
+    <section id="blog" class="blog-home">
+      <div class="container">
+        <div class="section-header">
+          <p class="eyebrow" data-i18n="bloghome.eyebrow">Blog</p>
+          <h2 data-i18n="bloghome.title">Fra bloggen</h2>
+          <p data-i18n="bloghome.sub">Små fortællinger om børneliv, forældretøven og de aftaler, der gerne må blive lidt lettere at få til at ske.</p>
+        </div>
+
+        <article class="blog-card" data-animate>
+          <a href="blog/lordag-formiddag/" class="blog-card-image"
+             data-i18n-aria="bloghome.cardAria"
+             aria-label="Læs Lørdag formiddag, og ingen har spurgt endnu">
+            <img src="assets/blog/playdate-19-04.jpg"
+                 alt="Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale"
+                 data-i18n-alt="bloghome.imageAlt"
+                 width="1408" height="768" loading="lazy" decoding="async">
+          </a>
+          <div class="blog-card-body">
+            <p class="post-meta" data-i18n="bloghome.date">20. april 2026 · Playdate</p>
+            <h3><a href="blog/lordag-formiddag/" data-i18n="bloghome.postTitle">Lørdag formiddag, og ingen har spurgt endnu</a></h3>
+            <p data-i18n="bloghome.excerpt">Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.</p>
+            <a href="blog/lordag-formiddag/" class="read-more" data-i18n="bloghome.read">Læs artiklen →</a>
+          </div>
+        </article>
+
+        <div class="blog-home-cta">
+          <a href="blog/" class="btn btn-outline" data-i18n="bloghome.viewAll">Se alle artikler →</a>
         </div>
       </div>
     </section>

--- a/js/blog-i18n.js
+++ b/js/blog-i18n.js
@@ -53,6 +53,7 @@
       "nav.about": "Om os",
       "nav.blog": "Blog",
       "nav.cta": "Tilmeld venteliste →",
+      "nav.menu": "Åbn menu",
       "footer.privacy": "Privatlivspolitik",
       "footer.terms": "Vilkår og betingelser",
       "footer.copy": "© 2026 Playdate. Alle rettigheder forbeholdes.",
@@ -75,6 +76,7 @@
       "nav.about": "About Us",
       "nav.blog": "Blog",
       "nav.cta": "Join Waitlist →",
+      "nav.menu": "Open menu",
       "footer.privacy": "Privacy Policy",
       "footer.terms": "Terms & Conditions",
       "footer.copy": "© 2026 Playdate. All rights reserved.",
@@ -154,6 +156,37 @@
     if (langBtn) {
       langBtn.addEventListener("click", function () {
         apply((document.documentElement.lang || DEFAULT_LANG) === "da" ? "en" : "da");
+      });
+    }
+
+    var nav = document.querySelector(".nav");
+    var navToggle = document.getElementById("nav-toggle");
+    var navMenu = document.getElementById("nav-menu");
+    if (nav && navToggle && navMenu) {
+      var setMenu = function (open) {
+        nav.setAttribute("data-menu-open", open ? "true" : "false");
+        navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+      };
+
+      navToggle.addEventListener("click", function () {
+        setMenu(nav.getAttribute("data-menu-open") !== "true");
+      });
+
+      navMenu.addEventListener("click", function (e) {
+        if (e.target.tagName === "A") setMenu(false);
+      });
+
+      document.addEventListener("click", function (e) {
+        if (nav.getAttribute("data-menu-open") !== "true") return;
+        if (nav.contains(e.target)) return;
+        setMenu(false);
+      });
+
+      document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape" && nav.getAttribute("data-menu-open") === "true") {
+          setMenu(false);
+          navToggle.focus();
+        }
       });
     }
   });

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -24,6 +24,7 @@ var I18N = (function () {
       "nav.cta": "Tilmeld venteliste →",
       "nav.ctaShort": "Tilmeld",
       "nav.ctaLaunched": "Download →",
+      "nav.menu": "Åbn menu",
       "lang.toggle": "EN",
 
       // Hero
@@ -93,6 +94,18 @@ var I18N = (function () {
       "founder.robert.bio": "Med 15+ års erfaring i cloud- og platform engineering bringer Robert dyb DevOps-ekspertise til teamet — fra CI/CD og Kubernetes til Terraform og multi-cloud arkitektur. Arrangør af Copenhagen Cloud Native meetups (2.000 medlemmer) og KCD Denmark, han er lige så engageret i community som i kode. Som far til to piger ved Robert på egen krop, at det sværeste ved en legeaftale ikke er at finde tiden — det er at opbygge nok tillid til en anden familie til at sige ja. Det problem er personligt for ham, og det er præcis hvad Playdate er bygget til at løse.",
       "mission.title": "Vores mission",
       "mission.text": "Hvert barn fortjener at opbygge meningsfulde venskaber gennem leg. Vi gør koordinering af legeaftaler ubesværet — om du er dansker eller international, hjemme eller på ferie. Teknologi bør bringe familier sammen, ikke gøre forældrerollen mere kompleks.",
+
+      // Blog teaser
+      "bloghome.eyebrow": "Blog",
+      "bloghome.title": "Fra bloggen",
+      "bloghome.sub": "Små fortællinger om børneliv, forældretøven og de aftaler, der gerne må blive lidt lettere at få til at ske.",
+      "bloghome.date": "20. april 2026 · Playdate",
+      "bloghome.postTitle": "Lørdag formiddag, og ingen har spurgt endnu",
+      "bloghome.excerpt": "Barnet spørger, om man skal lege med nogen i dag. Numrene ligger i telefonen. Alligevel bliver der ikke skrevet.",
+      "bloghome.read": "Læs artiklen →",
+      "bloghome.viewAll": "Se alle artikler →",
+      "bloghome.cardAria": "Læs Lørdag formiddag, og ingen har spurgt endnu",
+      "bloghome.imageAlt": "Et barn bygger LEGO lørdag formiddag, mens en forælder overvejer en legeaftale",
 
       // CTA / Waitlist
       "cta.badge": "🚀 Kommer snart",
@@ -166,6 +179,7 @@ var I18N = (function () {
       "nav.cta": "Join Waitlist →",
       "nav.ctaShort": "Join",
       "nav.ctaLaunched": "Download →",
+      "nav.menu": "Open menu",
       "lang.toggle": "DA",
 
       // Hero
@@ -235,6 +249,18 @@ var I18N = (function () {
       "founder.robert.bio": "With 15+ years in cloud and platform engineering, Robert brings deep DevOps expertise to the team — from CI/CD pipelines and Kubernetes to Terraform and multi-cloud architecture. Organiser of Copenhagen Cloud Native meetups (2,000 members) and KCD Denmark, he's as committed to community as he is to code. As a father of two girls, Robert knows first-hand that the hardest part of setting up a playdate isn't finding the time — it's building enough trust with another family to feel comfortable saying yes. That problem is personal to him, and it's exactly what Playdate is designed to solve.",
       "mission.title": "Our Mission",
       "mission.text": "Every child deserves the opportunity to build meaningful friendships through play. We're making playdate coordination effortless — whether you're a Danish native or an international expat, whether you're at home or on holiday. Technology should bring families together, not add complexity to parenting.",
+
+      // Blog teaser
+      "bloghome.eyebrow": "Blog",
+      "bloghome.title": "From the blog",
+      "bloghome.sub": "Small stories about children's friendships, parental hesitation, and the plans that should be easier to make happen.",
+      "bloghome.date": "April 20, 2026 · Playdate",
+      "bloghome.postTitle": "Saturday morning, and no one's asked yet",
+      "bloghome.excerpt": "The child asks if they can play with someone today. The numbers are in the phone. No one gets a message.",
+      "bloghome.read": "Read the article →",
+      "bloghome.viewAll": "See all articles →",
+      "bloghome.cardAria": "Read Saturday morning, and no one's asked yet",
+      "bloghome.imageAlt": "A child building LEGO on a Saturday morning while a parent considers arranging a playdate",
 
       // CTA / Waitlist
       "cta.badge": "🚀 Coming soon",
@@ -329,6 +355,10 @@ var I18N = (function () {
 
     document.querySelectorAll("[data-i18n-aria]").forEach(function (el) {
       el.setAttribute("aria-label", t(el.getAttribute("data-i18n-aria"), lang));
+    });
+
+    document.querySelectorAll("[data-i18n-alt]").forEach(function (el) {
+      el.setAttribute("alt", t(el.getAttribute("data-i18n-alt"), lang));
     });
 
     localStorage.setItem(STORAGE_KEY, lang);

--- a/js/main.js
+++ b/js/main.js
@@ -222,6 +222,39 @@
     onScroll();
   }
 
+  // ---- Mobile menu toggle ----
+
+  var navToggle = document.getElementById("nav-toggle");
+  var navMenu = document.getElementById("nav-menu");
+  if (navToggle && nav && navMenu) {
+    var setMenu = function (open) {
+      nav.setAttribute("data-menu-open", open ? "true" : "false");
+      navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+    };
+
+    navToggle.addEventListener("click", function () {
+      var open = nav.getAttribute("data-menu-open") !== "true";
+      setMenu(open);
+    });
+
+    navMenu.addEventListener("click", function (e) {
+      if (e.target.tagName === "A") setMenu(false);
+    });
+
+    document.addEventListener("click", function (e) {
+      if (nav.getAttribute("data-menu-open") !== "true") return;
+      if (nav.contains(e.target)) return;
+      setMenu(false);
+    });
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && nav.getAttribute("data-menu-open") === "true") {
+        setMenu(false);
+        navToggle.focus();
+      }
+    });
+  }
+
   // ---- Scroll-triggered animations ----
 
   var animated = document.querySelectorAll("[data-animate]");


### PR DESCRIPTION
## Summary

The blog was reachable only via a small nav link that disappeared entirely on mobile (top-nav links hidden via `display:none` with no hamburger fallback) and had no presence on the homepage itself. Two changes address both cases:

- **Mobile hamburger menu** — new toggle button opens a dropdown panel containing the full nav plus a CTA entry. The header "Join Waitlist" button moves into the dropdown on mobile so the header fits at 375px. Menu closes on link click, outside click, or Escape.
- **Homepage blog teaser** — new `<section id="blog" class="blog-home">` between `#founders` and `#cta`, showcasing the latest post ("Lørdag formiddag…") as a card with image, date, excerpt, "Read the article" link, and a "See all articles →" outline button linking to `/blog/`.

Same hamburger treatment applied to `blog/` and `blog/lordag-formiddag/` navs. `js/i18n.js` gains `data-i18n-alt` support and new `nav.menu` + `bloghome.*` keys in DA+EN; `blog-i18n.js` mirrors the toggle logic and key.

## Test plan

- [ ] Desktop (≥768px) — nav shows Features / How It Works / About Us / Blog + CTA button inline; no hamburger visible
- [ ] Mobile (<768px) — header shows logo + lang toggle + hamburger; tapping hamburger reveals dropdown with all nav items + CTA button
- [ ] Dropdown closes when: tapping a link, tapping outside the nav, or pressing Escape
- [ ] Homepage has a "Fra bloggen / From the blog" section between founders and CTA, linking to the post and to `/blog/`
- [ ] Language toggle still works on all pages (including new `bloghome.*` strings and image alt)
- [ ] `/blog/` and `/blog/lordag-formiddag/` pages render correctly with the new hamburger